### PR TITLE
feat(zsh-alias): add jupyter-notebook alias

### DIFF
--- a/_zshrc
+++ b/_zshrc
@@ -120,3 +120,4 @@ alias zshsource="source ~/.zshrc"
 alias zshconfig="vi ~/.zshrc"
 alias ohmyzsh="vi ~/.oh-my-zsh"
 
+alias jn="jupyter notebook"


### PR DESCRIPTION
perhaps the easiest way to start a notebook would be to type jn.

https://stackoverflow.com/a/50321456/3451822