### PR TITLE
feat: expo clear appache

### DIFF
--- a/bin/expo-clear-appcache.sh
+++ b/bin/expo-clear-appcache.sh
@@ -1,0 +1,18 @@
+#!/bin/zsh
+
+# Increase the amount of inotify watches
+# Learn about inotify https://manpage.me/?q=inotify
+# See https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers
+
+echo 99999999 | sudo tee -a /proc/sys/fs/inotify/max_user_watches
+echo 99999999 | sudo tee -a /proc/sys/fs/inotify/max_queued_events
+echo 99999999 | sudo tee -a /proc/sys/fs/inotify/max_user_instances
+
+# Remove all watches and associated triggers.
+# See https://facebook.github.io/watchman/docs/cmd/watch-del-all.html
+
+watchman watch-del-all
+
+# Clean Install
+
+npm ci

--- a/bin/fix_inotify_watches.sh
+++ b/bin/fix_inotify_watches.sh
@@ -1,3 +1,0 @@
-echo 99999999 | sudo tee -a /proc/sys/fs/inotify/max_user_watches
-echo 99999999 | sudo tee -a /proc/sys/fs/inotify/max_queued_events
-echo 99999999 | sudo tee -a /proc/sys/fs/inotify/max_user_instances


### PR DESCRIPTION
attempt to restore clean application cache

- using watchman to remove all watches and associated triggers
- increasing the amount of inotify file watches
- npm clean-install